### PR TITLE
refactor: phase 2C — services API/events split + barrel (no behavior change)

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,6 @@
-import tailwind from "@tailwindcss/postcss";
-import autoprefixer from "autoprefixer";
-
 export default {
-  plugins: [tailwind(), autoprefixer()],
+  plugins: {
+    '@tailwindcss/postcss': {},
+    autoprefixer: {},
+  },
 };

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -1,10 +1,9 @@
 /**
  * Services barrel.
- * Keeps legacy exports as-is (via './room.js'),
- * and offers structured entry points:
- *  - api: Firestore-facing operations
- *  - events: lightweight event bus
+ * - legacy surface via './room.js'
+ * - new API via './room.api.js'
+ * - events bus via './room.events.js'
  */
-export * from './room.js';              // legacy surface unchanged
-export * as api from './room.api.js';   // new structured API
-export * as events from './room.events.js'; // new event bus
+export * from './room.js';
+export * as api    from './room.api.js';
+export * as events from './room.events.js';

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -1,9 +1,10 @@
 /**
  * Services barrel.
- * - legacy surface via './room.js'
- * - new API via './room.api.js'
- * - events bus via './room.events.js'
+ * Keeps legacy exports as-is (via './room.js'),
+ * and offers structured entry points:
+ *  - api: Firestore-facing operations
+ *  - events: lightweight event bus
  */
-export * from './room.js';
-export * as api    from './room.api.js';
-export * as events from './room.events.js';
+export * from './room.js';              // legacy surface unchanged
+export * as api from './room.api.js';   // new structured API
+export * as events from './room.events.js'; // new event bus

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -1,9 +1,9 @@
 /**
  * Services barrel.
- * Keeps legacy exports as-is (via './room.js'), and offers structured entry points:
- *  - api: Firestore-facing operations (currently forwarded to legacy)
- *  - events: lightweight event bus ready for adoption
+ * - legacy surface via './room.js'
+ * - new API via './room.api.js'
+ * - events bus via './room.events.js'
  */
-export * from './room.js';             // legacy surface unchanged
-export * as api from './room.api.js';  // new: structured API facade
-export * as events from './room.events.js'; // new: event bus
+export * from './room.js';
+export * as api    from './room.api.js';
+export * as events from './room.events.js';

--- a/src/services/room.api.js
+++ b/src/services/room.api.js
@@ -9,14 +9,16 @@ import {
   onSnapshot,
 } from 'firebase/firestore';
 
-/** API layer (Phase 2C) - no legacy re-export here. */
+/** API layer (Phase 2C) — no legacy re-export here. */
 
+// Send a chat message to a room
 export async function sendMessage({ roomCode, uid, text }) {
   const db = getFirestore();
   const ref = collection(db, 'rooms', roomCode, 'messages');
   return await addDoc(ref, { uid, text, created: serverTimestamp() });
 }
 
+// Subscribe to messages; handler(items, snapshot)
 export function subscribeMessages(roomCode, handler, opts = {}) {
   const { limit = 200, order = 'asc' } = opts;
   const db  = getFirestore();
@@ -28,6 +30,6 @@ export function subscribeMessages(roomCode, handler, opts = {}) {
   );
   return onSnapshot(q, (snap) => {
     const items = snap.docs.map((d) => ({ id: d.id, ...d.data() }));
-    try { handler(items, snap); } catch {}
+    try { handler(items, snap); } catch { /* no-op */ }
   });
 }

--- a/src/services/room.api.js
+++ b/src/services/room.api.js
@@ -9,7 +9,7 @@ import {
   onSnapshot,
 } from 'firebase/firestore';
 
-/** API layer (Phase 2C) — no legacy re-export here. */
+/** API layer (Phase 2C) - no legacy re-export here. */
 
 export async function sendMessage({ roomCode, uid, text }) {
   const db = getFirestore();

--- a/src/services/room.events.js
+++ b/src/services/room.events.js
@@ -1,8 +1,3 @@
-/**
- * Minimal event bus for room-level events.
- * Non-breaking: your existing room.js events keep working;
- * this can be adopted gradually.
- */
 const listeners = new Map(); // event -> Set<fn>
 
 export function on(event, handler) {
@@ -10,14 +5,12 @@ export function on(event, handler) {
   listeners.get(event).add(handler);
   return () => off(event, handler);
 }
-
 export function off(event, handler) {
   const set = listeners.get(event);
   if (!set) return;
   set.delete(handler);
   if (set.size === 0) listeners.delete(event);
 }
-
 export function emit(event, payload) {
   const set = listeners.get(event);
   if (!set) return;
@@ -25,7 +18,5 @@ export function emit(event, payload) {
     try { fn(payload); } catch { /* no-op */ }
   }
 }
-
-// Optional shims
-export const addEvent = (payload) => emit('event', payload);
-export const onEvents  = (handler) => on('event', handler);
+export const addEvent = (p) => emit('event', p);
+export const onEvents = (h) => on('event', h);

--- a/src/services/room.events.js
+++ b/src/services/room.events.js
@@ -1,7 +1,3 @@
-/**
- * Minimal event bus for room-level events.
- * Non-breaking: your existing room.js events keep working; this is ready for gradual migration.
- */
 const listeners = new Map(); // event -> Set<fn>
 
 export function on(event, handler) {
@@ -9,23 +5,18 @@ export function on(event, handler) {
   listeners.get(event).add(handler);
   return () => off(event, handler);
 }
-
 export function off(event, handler) {
   const set = listeners.get(event);
-  if (set) {
-    set.delete(handler);
-    if (set.size === 0) listeners.delete(event);
-  }
+  if (!set) return;
+  set.delete(handler);
+  if (set.size === 0) listeners.delete(event);
 }
-
 export function emit(event, payload) {
   const set = listeners.get(event);
   if (!set) return;
   for (const fn of Array.from(set)) {
-    try { fn(payload); } catch (_) { /* no-op */ }
+    try { fn(payload); } catch {}
   }
 }
-
-/** Optional shims for familiar naming used in the UI */
 export const addEvent = (payload) => emit('event', payload);
-export const onEvents  = (handler) => on('event', handler);
+export const onEvents = (handler) => on('event', handler);

--- a/src/services/room.events.js
+++ b/src/services/room.events.js
@@ -5,12 +5,14 @@ export function on(event, handler) {
   listeners.get(event).add(handler);
   return () => off(event, handler);
 }
+
 export function off(event, handler) {
   const set = listeners.get(event);
   if (!set) return;
   set.delete(handler);
   if (set.size === 0) listeners.delete(event);
 }
+
 export function emit(event, payload) {
   const set = listeners.get(event);
   if (!set) return;
@@ -18,5 +20,7 @@ export function emit(event, payload) {
     try { fn(payload); } catch { /* no-op */ }
   }
 }
+
+// Optional shims
 export const addEvent = (p) => emit('event', p);
 export const onEvents = (h) => on('event', h);

--- a/src/services/room.events.js
+++ b/src/services/room.events.js
@@ -1,3 +1,8 @@
+/**
+ * Minimal event bus for room-level events.
+ * Non-breaking: your existing room.js events keep working;
+ * this can be adopted gradually.
+ */
 const listeners = new Map(); // event -> Set<fn>
 
 export function on(event, handler) {
@@ -5,18 +10,22 @@ export function on(event, handler) {
   listeners.get(event).add(handler);
   return () => off(event, handler);
 }
+
 export function off(event, handler) {
   const set = listeners.get(event);
   if (!set) return;
   set.delete(handler);
   if (set.size === 0) listeners.delete(event);
 }
+
 export function emit(event, payload) {
   const set = listeners.get(event);
   if (!set) return;
   for (const fn of Array.from(set)) {
-    try { fn(payload); } catch {}
+    try { fn(payload); } catch { /* no-op */ }
   }
 }
+
+// Optional shims
 export const addEvent = (payload) => emit('event', payload);
-export const onEvents = (handler) => on('event', handler);
+export const onEvents  = (handler) => on('event', handler);

--- a/src/services/room.js
+++ b/src/services/room.js
@@ -140,3 +140,4 @@ export function onEvents(roomCode, cb) {
 // --- Phase-2C.1 wrapper (keeps legacy imports working) ---
 export { sendMessage } from './room.api.js';
 
+export { subscribeMessages } from './room.api.js';


### PR DESCRIPTION
- Adds room.api.js (sendMessage, subscribeMessages) — no export *.
- Adds room.events.js (lightweight event bus).
- Adds services/index.js barrel.
- room.js keeps wrapper exports (backward compatible).
- Tailwind v4 PostCSS config.
No runtime changes.
